### PR TITLE
fix build for gcc12

### DIFF
--- a/Platforms/SurfaceDuoPkg/PrePi/ModuleEntryPoint.S
+++ b/Platforms/SurfaceDuoPkg/PrePi/ModuleEntryPoint.S
@@ -97,13 +97,13 @@ _SetupPrimaryCoreStack:
 
   mov v4.d[0], xzr
   mov v4.d[1], xzr
-  mov v5.2d, v4.2d 
-  mov v6.2d, v4.2d
-  mov v7.2d, v4.2d 
+  mov v5.16b, v4.16b
+  mov v6.16b, v4.16b
+  mov v7.16b, v4.16b
   
 _ClearStack: 
   /* Assumes StackBase is 128-bit aligned, StackSize is a multiple of 64B */
-  st4     {v4.2d, v5.2d, v6.2d, v7.2d}, [x3], #64  /* Fill every 64 bytes */
+  st4     {v4.16b, v5.16b, v6.16b, v7.16b}, [x3], #64  /* Fill every 64 bytes */
   cmp     x3, x2                                   /* Compare Size */ 
   b.lt     _ClearStack 
   


### PR DESCRIPTION
gcc's assembler don't support use 'v.2d', but support 'v.16b'
```
$ echo 'mov v6.2d, v4.2d' | aarch64-gcc/bin/aarch64-linux-gnu-as
{standard input}: Assembler messages:
{standard input}:1: Error: operand mismatch -- `mov v6.2d,v4.2d'
{standard input}:1: Info:    did you mean this?
{standard input}:1: Info:    	mov v6.8b, v4.8b
{standard input}:1: Info:    other valid variant(s):
{standard input}:1: Info:    	mov v6.16b, v4.16b
```
And actually, clang translate 'v.2d' to 'v.16b'.
```
$ echo 'mov v6.2d, v4.2d' | clang -target aarch64-linux-gnu- -c -xassembler - -o- | llvm-objdump -d -

<stdin>:	file format elf64-littleaarch64

Disassembly of section .text:

0000000000000000 <$x.0>:
       0: 86 1c a4 4e  	mov	v6.16b, v4.16b
```
Change 'v.2d' to 'v.16b' so that it can be compiled when using gcc.