### PR TITLE
Use UsbPwrCtrlDxe from CustomizedBinaries for oneplus-guacamole and oneplus-hotdog

### DIFF
--- a/Platforms/SurfaceDuo1Pkg/Device/asus-I001DC/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/asus-I001DC/DXE_Spec.inc
@@ -29,3 +29,9 @@
             SECTION PE32 = SurfaceDuo1Pkg/PatchedBinaries/PciHostBridgeDxe.efi
             SECTION UI = "PciHostBridge"
     }
+
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/kakao-pine/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/kakao-pine/DXE_Spec.inc
@@ -29,3 +29,9 @@
             SECTION PE32 = SurfaceDuo1Pkg/PatchedBinaries/PciHostBridgeDxe.efi
             SECTION UI = "PciHostBridge"
     }
+
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/lg-alphaplus/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/lg-alphaplus/DXE_Spec.inc
@@ -41,3 +41,9 @@
 #            SECTION PE32 = SurfaceDuo1Pkg/PatchedBinaries/Xiaomi/DisplayDxe.efi
 #            SECTION UI = "DisplayDxe"
 #    }
+
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/lg-betalm/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/lg-betalm/DXE_Spec.inc
@@ -30,3 +30,8 @@
             SECTION UI = "PciHostBridge"
     }
 
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/lg-flashlmdd/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/lg-flashlmdd/DXE_Spec.inc
@@ -30,3 +30,8 @@
             SECTION UI = "PciHostBridge"
     }
 
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/lg-mh2lm/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/lg-mh2lm/DXE_Spec.inc
@@ -30,3 +30,8 @@
             SECTION UI = "PciHostBridge"
     }
 
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/lg-mh2lm5g/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/lg-mh2lm5g/DXE_Spec.inc
@@ -30,3 +30,8 @@
             SECTION UI = "PciHostBridge"
     }
 
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/nubia-tp1803/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/nubia-tp1803/DXE_Spec.inc
@@ -43,3 +43,9 @@
             SECTION RAW = SurfaceDuo1Pkg/Device/nubia-tp1803/PatchedBinaries/Panel_jdi_hx83112a_1080p_vid.xml.raw
     }
 
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }
+

--- a/Platforms/SurfaceDuo1Pkg/Device/oneplus-guacamole/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/oneplus-guacamole/DXE_Spec.inc
@@ -29,3 +29,9 @@
             SECTION PE32 = SurfaceDuo1Pkg/PatchedBinaries/PciHostBridgeDxe.efi
             SECTION UI = "PciHostBridge"
     }
+
+    FILE DRIVER = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuo1Pkg/Device/$(TARGET_DEVICE)/CustomizedBinaries/UsbPwrCtrlDxe.efi
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/oneplus-hotdog/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/oneplus-hotdog/DXE_Spec.inc
@@ -29,3 +29,8 @@
             SECTION UI = "PciHostBridge"
     }
 
+    FILE DRIVER = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuo1Pkg/Device/$(TARGET_DEVICE)/CustomizedBinaries/UsbPwrCtrlDxe.efi
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/samsung-beyond1qlte/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/samsung-beyond1qlte/DXE_Spec.inc
@@ -37,3 +37,9 @@
             SECTION PE32 = SurfaceDuo1Pkg/PatchedBinaries/PciHostBridgeDxe.efi
             SECTION UI = "PciHostBridge"
     }
+
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/xiaomi-andromeda/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/xiaomi-andromeda/DXE_Spec.inc
@@ -49,3 +49,9 @@
             SECTION RAW = SurfaceDuo1Pkg/Device/xiaomi-andromeda/CustomizedBinaries/Panel_samsung_ea8076_fhd_amoled_cmd.xml.raw
     }
 
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }
+

--- a/Platforms/SurfaceDuo1Pkg/Device/xiaomi-cepheus/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/xiaomi-cepheus/DXE_Spec.inc
@@ -30,3 +30,9 @@
             SECTION UI = "PciHostBridge"
     }
 
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }
+

--- a/Platforms/SurfaceDuo1Pkg/Device/xiaomi-hercules/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/xiaomi-hercules/DXE_Spec.inc
@@ -30,3 +30,8 @@
             SECTION UI = "PciHostBridge"
     }
 
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/xiaomi-nabu/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/xiaomi-nabu/DXE_Spec.inc
@@ -29,3 +29,9 @@
             SECTION PE32 = SurfaceDuo1Pkg/PatchedBinaries/PciHostBridgeDxe.efi
             SECTION UI = "PciHostBridge"
     }
+
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/xiaomi-raphael/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/xiaomi-raphael/DXE_Spec.inc
@@ -30,3 +30,8 @@
             SECTION UI = "PciHostBridge"
     }
 
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Device/xiaomi-vayu/DXE_Spec.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/xiaomi-vayu/DXE_Spec.inc
@@ -30,3 +30,8 @@
             SECTION UI = "PciHostBridge"
     }
 
+    FILE DRIVER  = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
+            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
+            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
+            SECTION UI = "UsbPwrCtrlDxe"
+    }

--- a/Platforms/SurfaceDuo1Pkg/Include/DXE.inc
+++ b/Platforms/SurfaceDuo1Pkg/Include/DXE.inc
@@ -191,11 +191,6 @@
             SECTION UI = "AdcDxe"
     }
 
-    FILE DRIVER = 11faed4c-b21f-4d88-8e48-c4c28a1e50df {
-            SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section0.dxe.depex
-            SECTION PE32 = SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2/volume-0/file-2/section0/section1/volume-0/file-11faed4c-b21f-4d88-8e48-c4c28a1e50df/section1.pe
-            SECTION UI = "UsbPwrCtrlDxe"
-    }
 
     FILE DRIVER = 94f8a6a7-dc34-4101-88c1-99179cceae83 {
             SECTION DXE_DEPEX = SurfaceDuoBinaries/BOOT.XF.3.0-00527-SM8150LZB-1-202206/volume-0/file-2/section0/section1/volume-0/file-94f8a6a7-dc34-4101-88c1-99179cceae83/section0.dxe.depex


### PR DESCRIPTION
It is still not quite clear to me why the `UsbPwrCtrlDxe` from `SurfaceDuoBinaries/BOOT.XF.3.0.1-00243-SC8180XWZB-2` doesn't work *(atleast on my 7T Pro, whereas @sunflower2333 doesn't have this issue at all)* and these are my currently proposed changes to fix this.

These changes should not affect other devices and should not negatively affect both oneplus-hotdog and oneplus-guacamole.