### PR TITLE
FamilyPkg: RamPartitionDxe: Consider the situation of allocating an area as RAM before 0x80000000

### DIFF
--- a/Platforms/SurfaceDuoFamilyPkg/Driver/RamPartitionDxe/RamPartitionDxe.c
+++ b/Platforms/SurfaceDuoFamilyPkg/Driver/RamPartitionDxe/RamPartitionDxe.c
@@ -253,11 +253,14 @@ RamPartitionDxeInitialize(
               continue;
           }
 #endif
+
         // Perhaps some platforms allocated an area for RAM before 0x80000000.
         // Here we only consider the size of the area as 0x40000000.
-          if((RamPartitionEntries[0].Base < GENERIC_RAM_BASE) && ((GENERIC_RAM_BASE - RamPartitionEntries[0].Base) == 0x40000000)){
-              MemoryDescriptorEx[0].Address       = 0x40000000;
-              MemoryDescriptorEx[0].Length        = 0x40000000;
+        // Memory range: 0x40000000-0x80000000
+          if(RamPartitionEntries[i].Base == 0x40000000){
+              MemoryDescriptorEx[Index].Address       = 0x40000000;
+              MemoryDescriptorEx[Index].Length        = 0x40000000;
+              Index++;
               continue;
           }
 

--- a/Platforms/SurfaceDuoFamilyPkg/Driver/RamPartitionDxe/RamPartitionDxe.c
+++ b/Platforms/SurfaceDuoFamilyPkg/Driver/RamPartitionDxe/RamPartitionDxe.c
@@ -253,6 +253,13 @@ RamPartitionDxeInitialize(
               continue;
           }
 #endif
+        // Perhaps some platforms allocated an area for RAM before 0x80000000.
+        // Here we only consider the size of the area as 0x40000000.
+          if((RamPartitionEntries[0].Base < GENERIC_RAM_BASE) && ((GENERIC_RAM_BASE - RamPartitionEntries[0].Base) == 0x40000000)){
+              MemoryDescriptorEx[0].Address       = 0x40000000;
+              MemoryDescriptorEx[0].Length        = 0x40000000;
+              continue;
+          }
 
         // Update RAM Partitions.
         // You should have mapped 4GB RAM in PEI stage.


### PR DESCRIPTION
## Explain
* This situation occurs on the 6G device of MSM8998, and regardless of whether the Memory Base is 0x40000000 or 0x80000000, the kernel memory starts from 0x80000000, which can be clearly observed on uefiplat.cfg. Therefore, we are now attempting to use the memory portion between 0x40000000 and 0x80000000 for RAM.

* Kernel:
  * Kernel: 0x80000000, 0x05800000

* 6G Memory:
  * RAM Entry 0 : Base 0x0000000040000000  Size 0x00000000C0000000
  * RAM Entry 1 : Base 0x0000000100000000  Size 0x00000000BD8C0000

* 8G Memory:
  * RAM Entry 0 : Base 0x0000000080000000  Size 0x0000000100000000
  * RAM Entry 1 : Base 0x0000000180000000  Size 0x00000000FCCC0000

* **Only when the PR is tested to be effective and will not affect other platforms or devices can we merge it into the main branch.**