### PR TITLE
Kailua: Build: Enable the compilation parameters of armv9-a

### DIFF
--- a/Silicon/QC/Sm8550/QcomPkg/QcomPkg.dsc.inc
+++ b/Silicon/QC/Sm8550/QcomPkg/QcomPkg.dsc.inc
@@ -9,7 +9,7 @@
 #
 ##
 [BuildOptions.common]
-  *_*_*_CC_FLAGS = -march=armv8.2-a+crypto+rcpc 
+  *_*_*_CC_FLAGS = -march=armv9-a+crypto+rcpc 
 
 [PcdsFixedAtBuild.common]
   gArmTokenSpaceGuid.PcdSystemMemoryBase|0x80000000         # Starting address, 2GB Base


### PR DESCRIPTION
## Explain
* Among the currently supported Soc , a small number of ARM architectures are newer than ARMv8.2. Therefore, this PR aims to enable new compilation parameters for these Soc. Other Soc in a similar situation include the sm8475 and the sm8350 (perhaps ARMv8.4 can be enabled for it? This remains to be tested).
* This is a follow to "[Common: Configure '-march' flags separately for each Silicon](https://github.com/Project-Aloha/mu_aloha_platforms/commit/fda33502653447268fc4ac6e5ce000139aab1683)".

## Change
### SM8550
* kailua: Build: Enable the compilation parameters of armv9-a

## Notice
* Testing is required.