### PR TITLE
Set flag to indicate Qualcomm Technologies Inc. QRD8150 has an UFS2 chip

### DIFF
--- a/Platforms/SurfaceDuo1Pkg/Device/qcom-qrd8150/PcdsFixedAtBuild.dsc.inc
+++ b/Platforms/SurfaceDuo1Pkg/Device/qcom-qrd8150/PcdsFixedAtBuild.dsc.inc
@@ -7,3 +7,5 @@ gAndromedaPkgTokenSpaceGuid.PcdSmbiosSystemBrand|"Qualcomm"
 gAndromedaPkgTokenSpaceGuid.PcdSmbiosSystemRetailSku|"6"
 
 gAndromedaPkgTokenSpaceGuid.PcdABLProduct|"msmnile"
+
+gAndromedaPkgTokenSpaceGuid.PcdStorageHasUFS3|0


### PR DESCRIPTION
Fixes Windows boot issue on QRD8150 DVT1.2