### PR TITLE
Common: Solve some implicit declaration errors

### DIFF
--- a/Platforms/AndromedaPkg/Driver/SecureBootProvisioningDxe/SecureBootProvisioningDxe.c
+++ b/Platforms/AndromedaPkg/Driver/SecureBootProvisioningDxe/SecureBootProvisioningDxe.c
@@ -20,6 +20,7 @@
 #include <Library/UefiDriverEntryPoint.h>
 #include <Library/UefiLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/MemoryAllocationLib.h>
 #include <Library/MuSecureBootKeySelectorLib.h>
 
 #include <Guid/GlobalVariable.h>

--- a/Platforms/QcomModulePkg/Library/LibUfdt/sysdeps/libufdt_sysdeps_vendor.c
+++ b/Platforms/QcomModulePkg/Library/LibUfdt/sysdeps/libufdt_sysdeps_vendor.c
@@ -1,4 +1,6 @@
 #include "libufdt_sysdeps.h"
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
 #define EFI_DTBO_ERROR -1
 #define PRE_ALLOC_BUFFER_SZ (5 * 1024 * 1024)
 
@@ -232,6 +234,33 @@ char *dto_strdup(const char *s) {
 }
 
 char *dto_strchr(const char *s, int c) { return strchr(s, c); }
+
+unsigned long
+strtoul (
+  const char  *nptr,
+  char        **endptr,
+  int         base
+  )
+{
+  RETURN_STATUS  Status;
+  UINTN          ReturnValue;
+
+  ASSERT (base == 10 || base == 16);
+
+  if (base == 10) {
+    Status = AsciiStrDecimalToUintnS (nptr, endptr, &ReturnValue);
+  } else if (base == 16) {
+    Status = AsciiStrHexToUintnS (nptr, endptr, &ReturnValue);
+  } else {
+    Status = RETURN_INVALID_PARAMETER;
+  }
+
+  if (RETURN_ERROR (Status)) {
+    return MAX_UINTN;
+  }
+
+  return ReturnValue;
+}
 
 unsigned long int dto_strtoul(const char *nptr, char **endptr, int base) {
   return strtoul(nptr, endptr, base);


### PR DESCRIPTION
## Explain
* After upgrading to Ubuntu 24.04 and using Clang 18, some errors related to implicit declarations occurred. Therefore, this PR aims to propose some solutions for discussion and hopes to resolve this issue.

## Change
### QcomModulePkg
* Fix the implicit declaration error that occurs in Clang 18
  * The strtoul method has not yet appeared in the current version of the Mu Repo. The upstream Edk2 has supplemented the strtoul method for fdtlib in "edk2-stable202502". Therefore, this method is copied here to solve the problem in the current version.

### AndromedaPkg: 
* SecureBootProvisioningDxe: Supplement the missing MemoryAllocation Lib