### PR TITLE
AndromedaPkg: SecureBoot: Add support for dynamic changes/updates of SiPolicy

### DIFF
--- a/Platforms/AndromedaPkg/Driver/SecureBootProvisioningDxe/SecureBootProvisioningDxe.c
+++ b/Platforms/AndromedaPkg/Driver/SecureBootProvisioningDxe/SecureBootProvisioningDxe.c
@@ -185,6 +185,9 @@ TryWritePlatformSiPolicy(EFI_HANDLE SfsHandle)
       if (CompareMem(SiPolicyEfiSfsHash, mSiPolicyDefaultHash, SHA256_DIGEST_SIZE) == 0) {
         Status = SetSecureBootConfig(0);
         goto exit;
+      } else {
+        // If an update is required, then delete the original SiPolicy first.
+        PayloadFileProtocol->Delete(PayloadFileProtocol);
       }
     }
     // File does not exist, if SB is off, do not add the file.

--- a/Platforms/AndromedaPkg/Driver/SecureBootProvisioningDxe/SecureBootProvisioningDxe.c
+++ b/Platforms/AndromedaPkg/Driver/SecureBootProvisioningDxe/SecureBootProvisioningDxe.c
@@ -26,10 +26,7 @@
 #include <Library/MuSecureBootKeySelectorLib.h>
 
 #include <Guid/GlobalVariable.h>
-
-#include <Guid/FileSystemInfo.h>
 #include <Guid/FileInfo.h>
-#include <Guid/FileSystemVolumeLabelInfo.h>
 
 //
 // Global variables.

--- a/Platforms/AndromedaPkg/Driver/SecureBootProvisioningDxe/SecureBootProvisioningDxe.inf
+++ b/Platforms/AndromedaPkg/Driver/SecureBootProvisioningDxe/SecureBootProvisioningDxe.inf
@@ -17,9 +17,11 @@
   MdePkg/MdePkg.dec
   MsCorePkg/MsCorePkg.dec
   AndromedaPkg/AndromedaPkg.dec
+  CryptoPkg/CryptoPkg.dec
 
 [LibraryClasses]
   BaseLib
+  BaseCryptLib
   DebugLib
   DxeServicesLib
   MuSecureBootKeySelectorLib


### PR DESCRIPTION
## Explain
* As mentioned in "issues/483", when the SiPolicy in UEFI/Repo is updated, the SiPolicy in the ESP on the user's device cannot be updated correctly. This may lead to some problems with driver signature verification. Therefore, we are now attempting to use the SHA256 Hash to determine whether we need to update the SiPolicy, and this way, it will not operate on the FAT partition multiple times, which could affect the boot process.

## Change
* AndromedaPkg
  * Add support for dynamic changes/updates of SiPolicy.