### PR TITLE
Kodiak: Add PCD for UFS version setting

### DIFF
--- a/Platforms/KodiakPkg/Device/qcom-qrd7325/PcdsFixedAtBuild.dsc.inc
+++ b/Platforms/KodiakPkg/Device/qcom-qrd7325/PcdsFixedAtBuild.dsc.inc
@@ -11,3 +11,6 @@ gAndromedaPkgTokenSpaceGuid.PcdABLProduct|"yupik"
 # Display Caller
 gAndromedaPkgTokenSpaceGuid.PcdDisplayCallerExitDisableDisplay|FALSE
 gAndromedaPkgTokenSpaceGuid.PcdDisplayCallerStallBeforeEnable|0
+
+# Storage
+gAndromedaPkgTokenSpaceGuid.PcdStorageHasUFS3|1

--- a/Platforms/KodiakPkg/Device/samsung-a52sxq/PcdsFixedAtBuild.dsc.inc
+++ b/Platforms/KodiakPkg/Device/samsung-a52sxq/PcdsFixedAtBuild.dsc.inc
@@ -15,3 +15,6 @@ gAndromedaPkgTokenSpaceGuid.PcdABLProduct|"a52sxq"
 # Display Caller
 #gAndromedaPkgTokenSpaceGuid.PcdDisplayCallerExitDisableDisplay|FALSE
 #gAndromedaPkgTokenSpaceGuid.PcdDisplayCallerStallBeforeEnable|0
+
+# Storage
+gAndromedaPkgTokenSpaceGuid.PcdStorageHasUFS3|0

--- a/Silicon/QC/Sm7325/QcomPkg/Library/AcpiPlatformUpdateLib/AcpiPlatformUpdateLib.c
+++ b/Silicon/QC/Sm7325/QcomPkg/Library/AcpiPlatformUpdateLib/AcpiPlatformUpdateLib.c
@@ -33,7 +33,7 @@ PlatformUpdateAcpiTables(VOID)
   UINT16                              SDFE  = 0;
   UINT16                              SIDM  = 0;
   UINT32                              SUFS  = 0xFFFFFFFF;
-  UINT32                              PUS3  = 0x1;
+  UINT32                              PUS3  = FixedPcdGet32(PcdStorageHasUFS3);
   UINT32                              SUS3  = 0xFFFFFFFF;
   UINT32                             *pSIDT = (UINT32 *)0x784180;
   UINT32                              SIDT  = (*pSIDT & 0xFF00000) >> 20;

--- a/Silicon/QC/Sm7325/QcomPkg/Library/AcpiPlatformUpdateLib/AcpiPlatformUpdateLib.inf
+++ b/Silicon/QC/Sm7325/QcomPkg/Library/AcpiPlatformUpdateLib/AcpiPlatformUpdateLib.inf
@@ -37,6 +37,7 @@
 
 [FixedPcd]
   gArmPlatformTokenSpaceGuid.PcdClusterCount
+  gAndromedaPkgTokenSpaceGuid.PcdStorageHasUFS3
 
 [Protocols]
   gEfiChipInfoProtocolGuid                      ## CONSUMES


### PR DESCRIPTION
Add PCD for UFS version setting, since not all devices have UFS3.

A52sxq uses UFS 2 and with lower voltages it somehow worked all this time.
My QRD7325 needs fixing so I can't check whether it has UFS3 or not, so I set it to 3 for now to not break anything.